### PR TITLE
Allow non-200 response codes

### DIFF
--- a/src/cc/arduino/plugins/wifi101/flashers/java/SSLCertDownloader.java
+++ b/src/cc/arduino/plugins/wifi101/flashers/java/SSLCertDownloader.java
@@ -80,11 +80,9 @@ public class SSLCertDownloader {
 		connection.setHostnameVerifier((str, sess) -> true);
 
 		connection.setSSLSocketFactory(ssl.getSocketFactory());
+		connection.getResponseCode();
 
-		Certificate[] certificates = null;
-		if (connection.getResponseCode() > 0) {
-			certificates = connection.getServerCertificates();
-		}
+		Certificate[] certificates = connection.getServerCertificates();
 
 		connection.disconnect();
 		return certificates;

--- a/src/cc/arduino/plugins/wifi101/flashers/java/SSLCertDownloader.java
+++ b/src/cc/arduino/plugins/wifi101/flashers/java/SSLCertDownloader.java
@@ -82,7 +82,7 @@ public class SSLCertDownloader {
 		connection.setSSLSocketFactory(ssl.getSocketFactory());
 
 		Certificate[] certificates = null;
-		if (connection.getResponseCode() == 200) {
+		if (connection.getResponseCode() > 0) {
 			certificates = connection.getServerCertificates();
 		}
 


### PR DESCRIPTION
Before domain's like `api.twitter.com` where failing because of 404 error.

http://forum.arduino.cc/index.php?topic=419233.0

cc/ @cmaglie @dcuartielles 
