### PR TITLE
Certificates with UTF8 strings in the Subject hash wrong SHA hash

### DIFF
--- a/src/cc/arduino/plugins/wifi101/certs/WiFi101Certificate.java
+++ b/src/cc/arduino/plugins/wifi101/certs/WiFi101Certificate.java
@@ -45,6 +45,7 @@ import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1OutputStream;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.DERPrintableString;
+import org.bouncycastle.asn1.DERUTF8String;
 import org.bouncycastle.asn1.DLSequence;
 import org.bouncycastle.asn1.DLSet;
 import org.bouncycastle.asn1.x509.Time;
@@ -168,6 +169,11 @@ public class WiFi101Certificate {
 			// System.out.println("'" + s.getString() + "'");
 			return s.getString().getBytes();
 		}
+		else if (obj instanceof DERUTF8String) {
+			DERUTF8String s = (DERUTF8String) obj;
+			return s.getString().getBytes();
+		}
+
 		ByteArrayOutputStream res = new ByteArrayOutputStream();
 		if (obj instanceof DLSequence) {
 			DLSequence s = (DLSequence) obj;

--- a/src/cc/arduino/plugins/wifi101/certs/WiFi101Certificate.java
+++ b/src/cc/arduino/plugins/wifi101/certs/WiFi101Certificate.java
@@ -168,8 +168,7 @@ public class WiFi101Certificate {
 			DERPrintableString s = (DERPrintableString) obj;
 			// System.out.println("'" + s.getString() + "'");
 			return s.getString().getBytes();
-		}
-		else if (obj instanceof DERUTF8String) {
+		} else if (obj instanceof DERUTF8String) {
 			DERUTF8String s = (DERUTF8String) obj;
 			return s.getString().getBytes();
 		}


### PR DESCRIPTION
Certificates with UTF8 strings in the Subject were not handled properly when creating the SHA1 hash.  This should fix issue #23 .  If you have a test suite I recommend adding this as a regression test.