### PR TITLE
Replace use of javax.xml.bind.DatatypeConverter

### DIFF
--- a/src/cc/arduino/plugins/wifi101/certs/WiFi101Certificate.java
+++ b/src/cc/arduino/plugins/wifi101/certs/WiFi101Certificate.java
@@ -38,8 +38,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
-import javax.xml.bind.DatatypeConverter;
-
+import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1OutputStream;
@@ -103,7 +102,7 @@ public class WiFi101Certificate {
 		v1Data = v1Res.toByteArray();
 
 		byte[] digest = MessageDigest.getInstance("SHA-1").digest(v0Data);
-		hash = DatatypeConverter.printHexBinary(digest).substring(0, 6);
+		hash = Hex.encodeHexString(digest).substring(0, 6);
 	}
 
 	@Override


### PR DESCRIPTION
DatatypeConverter was deprecated in Java 9 and has been removed in Java 11. Instead of DatatypeConverter#printHexBinary we use the equivalent method Hex#encodeHexString from the commons-codec library, which we already require anyway (see build.sh).

(My problem is, that I need to run Arduino IDE on Java 11 (or maybe 10), because otherwise the Serial Monitor won't work, and I need to run Arduino IDE on Java 8 (or maybe 9), to upload certificates via this plug-in. Since my change should make it work on all Java versions, I thought it would be a useful contribution.)